### PR TITLE
Use cogs-client-react 1.+

### DIFF
--- a/template.json
+++ b/template.json
@@ -5,7 +5,7 @@
       "start": "cross-env BROWSER=scripts/openSimulator.js PORT=3001 react-scripts start"
     },
     "dependencies": {
-      "@clockworkdog/cogs-client-react": "1.1"
+      "@clockworkdog/cogs-client-react": "1"
     },
     "devDependencies": {
       "@types/react": "18",


### PR DESCRIPTION
This change means we don't have to keep updating this repo when release a new 1.X.Y version of `cogs-client-react`