### PR TITLE
Create symlink on `postinstall`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+./template/public/cogs-plugin-manifest.js

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ npx create-react-app --template @clockworkdog/cogs-client my-custom-client-conte
 yarn create react-app --template @clockworkdog/cogs-client my-custom-client-content
 
 cd my-custom-client-content
+
+npm install
+# OR
+yarn
 ```
 
 See the generated [README.md](template/README.md) for instructions on how to use this project with COGS.

--- a/template.json
+++ b/template.json
@@ -2,6 +2,7 @@
   "package": {
     "homepage": "./",
     "scripts": {
+      "postinstall": "node scripts/createManifestSymlink.js",
       "start": "cross-env BROWSER=scripts/openSimulator.js PORT=3001 react-scripts start"
     },
     "dependencies": {

--- a/template/public/cogs-plugin-manifest.js
+++ b/template/public/cogs-plugin-manifest.js
@@ -1,1 +1,0 @@
-../src/cogs-plugin-manifest.js

--- a/template/scripts/createManifestSymlink.js
+++ b/template/scripts/createManifestSymlink.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+const originalFile = path.join(__dirname, "..", "src", "cogs-plugin-manifest.js");
+const symlinkToCreate = path.join("..", "public", "cogs-plugin-manifest.js");
+
+// On Windows we need to use an absolute path to create the "junction" link as a non-admin user
+// so we create a junction using the absolute path
+if (process.platform === "win32") {
+  fs.link(originalFile, path.resolve(__dirname, symlinkToCreate), (error) => {
+    if (error) {
+      throw error;
+    }
+    console.log("Created hard link:", originalFile, "->", symlinkToCreate);
+  });
+} else {
+  fs.symlink(originalFile, symlinkToCreate, (error) => {
+    if (error) {
+      throw error;
+    }
+    console.log("Created symlink:", originalFile, "->", symlinkToCreate);
+  });
+}


### PR DESCRIPTION
This change removes the symlink from the repo and instead creates it when `yarn` or `npm install` is run.

Note that `create-react-app` fetches dependencies when run but **does not** run `install` or `postinstall` hooks so users will need to run `yarn` or `npm install` manually to get the full setup.

I think this is the best we can do for now.

Tested on Windows and macOS with:

```sh
npx create-react-app template-test --template "file:./cra-template-cogs-client"
cd template-test
npm i
```